### PR TITLE
refactor: minor naming changes for consistency with ecosystem

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './lib/errors/LoaderError';
 export * from './lib/errors/MissingExportsError';
 export * from './lib/internal/RootScan';
+export * from './lib/shared/Container';
 export * from './lib/strategies/ILoaderStrategy';
 export * from './lib/strategies/LoaderStrategy';
 export * from './lib/structures/AliasPiece';

--- a/src/lib/shared/Container.ts
+++ b/src/lib/shared/Container.ts
@@ -1,8 +1,10 @@
 /**
  * Represents the data from [[Container]] and may be used for dependency injection.
  * Libraries can provide strict typing by augmenting this module, check
- * {@link https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation module augmentation}
+ * [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation)
  * for more information.
+ *
+ * The data from this interface is available at {@link container}.
  */
 export interface Container extends Record<PropertyKey, unknown> {}
 

--- a/src/lib/shared/Container.ts
+++ b/src/lib/shared/Container.ts
@@ -1,0 +1,74 @@
+/**
+ * Represents the data from [[Container]] and may be used for dependency injection.
+ * Libraries can provide strict typing by augmenting this module, check
+ * {@link https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation module augmentation}
+ * for more information.
+ */
+export interface Container extends Record<PropertyKey, unknown> {}
+
+/**
+ * The injected variables that will be accessible to any place. To add an extra property, simply add a property with a
+ * regular assignment, and it will be available in all places simultaneously.
+ *
+ * @example
+ * ```typescript
+ * // Add a reference to the Client:
+ * import { container } from '(at)sapphire/pieces';
+ *
+ * export class SapphireClient extends Client {
+ *   constructor(options) {
+ *     super(options);
+ *
+ *     container.client = this;
+ *   }
+ * }
+ *
+ * // Can be placed anywhere in a TypeScript file, for JavaScript projects,
+ * // you can create an `augments.d.ts` and place the code there.
+ * declare module '(at)sapphire/pieces' {
+ *   interface Container {
+ *     client: SapphireClient;
+ *   }
+ * }
+ *
+ * // In any piece, core, plugin, or custom:
+ * export class UserCommand extends Command {
+ *   public run(message, args) {
+ *     // The injected client is available here:
+ *     const { client } = this.container;
+ *
+ *     // ...
+ *   }
+ * }
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // In a plugin's context, e.g. API:
+ * class Api extends Plugin {
+ *   static [postInitialization]() {
+ *     const server = new Server(this);
+ *     container.server = server;
+ *
+ *     // ...
+ *   }
+ * }
+ *
+ * declare module '(at)sapphire/pieces' {
+ *   interface Container {
+ *     server: Server;
+ *   }
+ * }
+ *
+ * // In any piece, even those that aren't routes nor middlewares:
+ * export class UserRoute extends Route {
+ *   public [methods.POST](message, args) {
+ *     // The injected server is available here:
+ *     const { server } = this.container;
+ *
+ *     // ...
+ *   }
+ * }
+ * ```
+ */
+export const container: Container = {};

--- a/src/lib/shared/Container.ts
+++ b/src/lib/shared/Container.ts
@@ -1,12 +1,16 @@
 /**
- * Represents the data from [[Container]] and may be used for dependency injection.
- * Libraries can provide strict typing by augmenting this module, check
- * [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation)
- * for more information.
+ * Represents the type of the properties injected into the container, which is available at {@link container}.
  *
- * The data from this interface is available at {@link container}.
+ * Because Sapphire works as a standalone framework (independent of external libraries), there is a need to pass data
+ * from one place to another, which would vary depending on the user and their use-cases.
+ *
+ * Furthermore, plugins may use this structure to add properties referencing to the plugin's objects so they can be
+ * accessed by both the user and the plugin at any moment and at any place.
+ *
+ * Finally, both library developers and bot developers should augment the Container interface from this module using
+ * [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).
  */
-export interface Container extends Record<PropertyKey, unknown> {}
+export interface Container {}
 
 /**
  * The injected variables that will be accessible to any place. To add an extra property, simply add a property with a

--- a/src/lib/strategies/LoaderStrategy.ts
+++ b/src/lib/strategies/LoaderStrategy.ts
@@ -13,7 +13,7 @@ import { classExtends, isClass } from './Shared';
  * Modules and CommonJS with reloading support.
  */
 export class LoaderStrategy<T extends Piece> implements ILoaderStrategy<T> {
-	private readonly clientESM: boolean = getRootData().type === 'ESM';
+	private readonly clientUsesESModules: boolean = getRootData().type === 'ESM';
 	private readonly supportedExtensions: readonly string[] = ['.js', '.cjs', '.mjs'];
 
 	public filter(path: string): FilterResult {
@@ -30,7 +30,7 @@ export class LoaderStrategy<T extends Piece> implements ILoaderStrategy<T> {
 	}
 
 	public async preload(file: ModuleData): AsyncPreloadResult<T> {
-		const mjs = file.extension === '.mjs' || (file.extension === '.js' && this.clientESM);
+		const mjs = file.extension === '.mjs' || (file.extension === '.js' && this.clientUsesESModules);
 		if (mjs) {
 			const url = pathToFileURL(file.path);
 			url.searchParams.append('d', Date.now().toString());

--- a/src/lib/structures/Piece.ts
+++ b/src/lib/structures/Piece.ts
@@ -1,13 +1,6 @@
+import { container, Container } from '../shared/Container';
 import type { Awaited } from '../strategies/ILoaderStrategy';
 import type { Store } from './Store';
-
-/**
- * Represents the data from [[PieceContext.extras]] and may be used for dependency injection.
- * Libraries can provide strict typing by augmenting this module, check
- * {@link https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation module augmentation}
- * for more information.
- */
-export interface PieceContextExtras extends Record<PropertyKey, unknown> {}
 
 /**
  * The context for the piece, contains extra information from the store,
@@ -79,11 +72,11 @@ export class Piece {
 	}
 
 	/**
-	 * The context given by the store.
-	 * @see Store.injectedContext
+	 * A reference to the [[container]] object for ease of use.
+	 * @see container
 	 */
-	public get context(): PieceContextExtras {
-		return this.store.context;
+	public get container(): Container {
+		return container;
 	}
 
 	/**

--- a/src/lib/structures/Piece.ts
+++ b/src/lib/structures/Piece.ts
@@ -72,7 +72,7 @@ export class Piece {
 	}
 
 	/**
-	 * A reference to the [[container]] object for ease of use.
+	 * A reference to the {@link Container} object for ease of use.
 	 * @see container
 	 */
 	public get container(): Container {

--- a/src/lib/structures/Store.ts
+++ b/src/lib/structures/Store.ts
@@ -2,9 +2,10 @@ import Collection from '@discordjs/collection';
 import { promises as fsp } from 'fs';
 import { join } from 'path';
 import { LoaderError, LoaderErrorType } from '../errors/LoaderError';
+import { container, Container } from '../shared/Container';
 import type { Constructor, ILoaderResultEntry, ILoaderStrategy, ModuleData } from '../strategies/ILoaderStrategy';
 import { LoaderStrategy } from '../strategies/LoaderStrategy';
-import type { Piece, PieceContextExtras } from './Piece';
+import type { Piece } from './Piece';
 
 /**
  * The options for the store, this features both hooks (changes the behaviour) and handlers (similar to event listeners).
@@ -65,10 +66,11 @@ export class Store<T extends Piece> extends Collection<string, T> {
 	}
 
 	/**
-	 * The extras to be used for dependency injection in all pieces. Returns a reference of [[Store.defaultExtras]].
+	 * A reference to the [[container]] object for ease of use.
+	 * @see container
 	 */
-	public get context(): PieceContextExtras {
-		return Store.injectedContext;
+	public get container(): Container {
+		return container;
 	}
 
 	/**
@@ -259,73 +261,6 @@ export class Store<T extends Piece> extends Collection<string, T> {
 			if (error.code !== 'ENOENT') this.strategy.onError(error, path);
 		}
 	}
-
-	/**
-	 * The injected variables that will be accessible to all stores and pieces. To add an extra property, simply mutate
-	 * the object to add it, and this will update all stores and pieces simultaneously.
-	 *
-	 * @example
-	 * ```typescript
-	 * // Add a reference to the Client:
-	 * import { Store } from '(at)sapphire/pieces';
-	 *
-	 * export class SapphireClient extends Client {
-	 *   constructor(options) {
-	 *     super(options);
-	 *
-	 *     Store.injectedContext.client = this;
-	 *   }
-	 * }
-	 *
-	 * // Can be placed anywhere in a TypeScript file, for JavaScript projects,
-	 * // you can create an `augments.d.ts` and place the code there.
-	 * declare module '(at)sapphire/pieces' {
-	 *   interface PieceContextExtras {
-	 *     client: SapphireClient;
-	 *   }
-	 * }
-	 *
-	 * // In any piece, core, plugin, or custom:
-	 * export class UserCommand extends Command {
-	 *   public run(message, args) {
-	 *     // The injected client is available here:
-	 *     const { client } = this.context;
-	 *
-	 *     // ...
-	 *   }
-	 * }
-	 * ```
-	 *
-	 * @example
-	 * ```typescript
-	 * // In a plugin's context, e.g. API:
-	 * class Api extends Plugin {
-	 *   static [postInitialization]() {
-	 *     const server = new Server(this);
-	 *     Store.injectedContext.server = server;
-	 *
-	 *     // ...
-	 *   }
-	 * }
-	 *
-	 * declare module '(at)sapphire/pieces' {
-	 *   interface PieceContextExtras {
-	 *     server: Server;
-	 *   }
-	 * }
-	 *
-	 * // In any piece, even those that aren't routes nor middlewares:
-	 * export class UserRoute extends Route {
-	 *   public [methods.POST](message, args) {
-	 *     // The injected server is available here:
-	 *     const { server } = this.context;
-	 *
-	 *     // ...
-	 *   }
-	 * }
-	 * ```
-	 */
-	public static injectedContext: PieceContextExtras = {};
 
 	/**
 	 * The default strategy, defaults to [[LoaderStrategy]], which is constructed on demand when a store is constructed,

--- a/src/lib/structures/Store.ts
+++ b/src/lib/structures/Store.ts
@@ -66,7 +66,7 @@ export class Store<T extends Piece> extends Collection<string, T> {
 	}
 
 	/**
-	 * A reference to the [[container]] object for ease of use.
+	 * A reference to the {@link Container} object for ease of use.
 	 * @see container
 	 */
 	public get container(): Container {


### PR DESCRIPTION
- **BREAKING CHANGE**: Renamed `PieceContextExtras` to `Container`, usage and augmentation is the same.
- **BREAKING CHANGE**: Removed `Store.injectedContext`, use globally exported `container` variable instead.
- **BREAKING CHANGE**: Renamed `Store#context` to `Store#container`.
- **BREAKING CHANGE**: Renamed `Piece#context` to `Piece#container`.
