### PR TITLE
feat(store): add `unloadAll`

### DIFF
--- a/src/lib/strategies/ILoaderStrategy.ts
+++ b/src/lib/strategies/ILoaderStrategy.ts
@@ -127,6 +127,12 @@ export interface ILoaderStrategy<T extends Piece> {
 	onUnload(store: Store<T>, piece: T): Awaited<unknown>;
 
 	/**
+	 * Called after all pieces have been unloaded.
+	 * @param store The store that unloaded all pieces.
+	 */
+	onUnloadAll(store: Store<T>): Awaited<unknown>;
+
+	/**
 	 * @param error The error that was thrown.
 	 * @param path The path of the file that caused the error to be thrown.
 	 */

--- a/src/lib/strategies/LoaderStrategy.ts
+++ b/src/lib/strategies/LoaderStrategy.ts
@@ -92,6 +92,10 @@ export class LoaderStrategy<T extends Piece> implements ILoaderStrategy<T> {
 		return undefined;
 	}
 
+	public onUnloadAll(): unknown {
+		return undefined;
+	}
+
 	public onError(error: Error, path: string): void {
 		console.error(`Error when loading '${path}':`, error);
 	}


### PR DESCRIPTION
Also removed an instance of `Map#clear`, which resulted on pieces to be removed but not unloaded, which causes issues specially with /framework's listeners.
