### PR TITLE
refactor: update to v3

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,6 @@ export * from './lib/strategies/LoaderStrategy';
 export * from './lib/structures/AliasPiece';
 export * from './lib/structures/AliasStore';
 export * from './lib/structures/Piece';
+export * from './lib/structures/PieceLocation';
 export * from './lib/structures/Store';
 export * from './lib/structures/StoreRegistry';

--- a/src/lib/strategies/ILoaderStrategy.ts
+++ b/src/lib/strategies/ILoaderStrategy.ts
@@ -23,6 +23,16 @@ export interface ModuleData {
 }
 
 /**
+ * The hydrated module data.
+ */
+export interface HydratedModuleData extends ModuleData {
+	/**
+	 * The directory the module was loaded from.
+	 */
+	root: string;
+}
+
+/**
  * The result from the filter.
  */
 export type FilterResult = ModuleData | null;
@@ -104,7 +114,7 @@ export interface ILoaderStrategy<T extends Piece> {
 	 * }
 	 * ```
 	 */
-	load(store: Store<T>, file: ModuleData): ILoaderResult<T>;
+	load(store: Store<T>, file: HydratedModuleData): ILoaderResult<T>;
 
 	/**
 	 * Called after a piece has been loaded, but before {@link Piece.onLoad} and {@link Store.set}.

--- a/src/lib/structures/AliasPiece.ts
+++ b/src/lib/structures/AliasPiece.ts
@@ -1,4 +1,4 @@
-import { Piece, PieceContext, PieceOptions } from './Piece';
+import { Piece, PieceContext, PieceJSON, PieceOptions } from './Piece';
 
 export interface AliasPieceOptions extends PieceOptions {
 	/**
@@ -25,10 +25,17 @@ export class AliasPiece extends Piece {
 	/**
 	 * Defines the `JSON.stringify` behavior of this alias piece.
 	 */
-	public toJSON(): Record<string, any> {
+	public toJSON(): AliasPieceJSON {
 		return {
 			...super.toJSON(),
 			aliases: this.aliases.slice()
 		};
 	}
+}
+
+/**
+ * The return type of {@link AliasPiece.toJSON}.
+ */
+export interface AliasPieceJSON extends PieceJSON {
+	aliases: string[];
 }

--- a/src/lib/structures/Piece.ts
+++ b/src/lib/structures/Piece.ts
@@ -1,5 +1,6 @@
 import type { Awaited } from '@sapphire/utilities';
 import { container, Container } from '../shared/Container';
+import { PieceLocation, PieceLocationJSON } from './PieceLocation';
 import type { Store } from './Store';
 
 /**
@@ -8,7 +9,12 @@ import type { Store } from './Store';
  */
 export interface PieceContext {
 	/**
-	 * The path the module was loaded from.
+	 * The root directory the piece was loaded from.
+	 */
+	readonly root: string;
+
+	/**
+	 * The path the module was loaded from, relative to {@link PieceContext.root}.
 	 */
 	readonly path: string;
 
@@ -50,9 +56,9 @@ export class Piece {
 	public readonly store: Store<Piece>;
 
 	/**
-	 * The path to the piece's file.
+	 * The location metadata for the piece's file.
 	 */
-	public readonly path: string;
+	public readonly location: PieceLocation;
 
 	/**
 	 * The name of the piece.
@@ -66,7 +72,7 @@ export class Piece {
 
 	public constructor(context: PieceContext, options: PieceOptions = {}) {
 		this.store = context.store;
-		this.path = context.path;
+		this.location = new PieceLocation(context.path, context.root);
 		this.name = options.name ?? context.name;
 		this.enabled = options.enabled ?? true;
 	}
@@ -107,17 +113,26 @@ export class Piece {
 	 * Reloads the piece by loading the same path in the store.
 	 */
 	public async reload() {
-		await this.store.load(this.path);
+		await this.store.load(this.location.root, this.location.relative);
 	}
 
 	/**
 	 * Defines the `JSON.stringify` behavior of this piece.
 	 */
-	public toJSON(): Record<string, any> {
+	public toJSON(): PieceJSON {
 		return {
-			path: this.path,
+			location: this.location.toJSON(),
 			name: this.name,
 			enabled: this.enabled
 		};
 	}
+}
+
+/**
+ * The return type of {@link Piece.toJSON}.
+ */
+export interface PieceJSON {
+	location: PieceLocationJSON;
+	name: string;
+	enabled: boolean;
 }

--- a/src/lib/structures/PieceLocation.ts
+++ b/src/lib/structures/PieceLocation.ts
@@ -1,0 +1,100 @@
+import { basename, relative, sep } from 'path';
+
+/**
+ * The metadata class used for {@link Piece}s.
+ */
+export class PieceLocation {
+	/**
+	 * The full path to the file.
+	 */
+	public readonly full: string;
+
+	/**
+	 * The root directory the file was found from.
+	 */
+	public readonly root: string;
+
+	/**
+	 * @param full The full path to the file.
+	 * @param root The root directory the file was found from.
+	 */
+	public constructor(full: string, root: string) {
+		this.full = full;
+		this.root = root;
+	}
+
+	/**
+	 * The relative path between {@link PieceLocation.root} and {@link PieceLocation.full}.
+	 * @example
+	 * ```typescript
+	 * const location = new PieceLocation(
+	 * 	'/usr/src/app/commands',
+	 * 	'/usr/src/app/commands/general/ping.js'
+	 * );
+	 *
+	 * console.log(location.relative);
+	 * // → 'general/ping.js'
+	 * ```
+	 */
+	public get relative(): string {
+		return relative(this.root, this.full);
+	}
+
+	/**
+	 * The names of the directories that separate {@link PieceLocation.root} and {@link PieceLocation.full}.
+	 * @example
+	 * ```typescript
+	 * const location = new PieceLocation(
+	 * 	'/usr/src/app/commands',
+	 * 	'/usr/src/app/commands/games/multiplayer/connect-four.js'
+	 * );
+	 *
+	 * console.log(location.directories);
+	 * // → ['games', 'multiplayer']
+	 * ```
+	 */
+	public get directories(): string[] {
+		return this.relative.split(sep).slice(0, -1);
+	}
+
+	/**
+	 * The name and extension of the file that was loaded, extracted from {@link PieceLocation.full}.
+	 * @example
+	 * ```typescript
+	 * const location = new PieceLocation(
+	 * 	'/usr/src/app/commands',
+	 * 	'/usr/src/app/commands/games/multiplayer/connect-four.js'
+	 * );
+	 *
+	 * console.log(location.name);
+	 * // → 'connect-four.js'
+	 * ```
+	 */
+	public get name(): string {
+		return basename(this.full);
+	}
+
+	/**
+	 * Defines the `JSON.stringify` behavior of this structure.
+	 */
+	public toJSON(): PieceLocationJSON {
+		return {
+			directories: this.directories,
+			full: this.full,
+			name: this.name,
+			relative: this.relative,
+			root: this.root
+		};
+	}
+}
+
+/**
+ * The return type of {@link PieceLocation.toJSON}.
+ */
+export interface PieceLocationJSON {
+	directories: string[];
+	full: string;
+	name: string;
+	relative: string;
+	root: string;
+}


### PR DESCRIPTION
## Changes

- Added `PieceLocation`.
- **AliasPiece**: strict type `toJSON()`.
- **ILoaderStrategy**: Added `HydratedModuleData` type.
- **Piece**: added `location` property, containing the file's metadata.
- **Piece**: strict type `toJSON()`.
- :warning: **BREAKING CHANGE**: Changed `Store#load` to take `root` and `path`.
- :warning: **BREAKING CHANGE**: Make `ILoaderStrategy#load` take `HydratedModuleData`.
- :warning: **BREAKING CHANGE**: Remove `Piece#path`, use `#location` instead.
