### PR TITLE
style: create namespaces for `Piece` and `AliasPiece`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"@commitlint/config-conventional": "^14.1.0",
 		"@favware/npm-deprecate": "^1.0.4",
 		"@favware/rollup-type-bundler": "^1.0.6",
-		"@sapphire/eslint-config": "^4.0.3",
+		"@sapphire/eslint-config": "^4.0.4",
 		"@sapphire/prettier-config": "^1.2.4",
 		"@sapphire/ts-config": "^3.1.4",
 		"@types/node": "^16.11.6",

--- a/src/lib/structures/AliasPiece.ts
+++ b/src/lib/structures/AliasPiece.ts
@@ -40,3 +40,9 @@ export interface AliasPieceJSON extends PieceJSON {
 	aliases: string[];
 	options: AliasPieceOptions;
 }
+
+export namespace AliasPiece {
+	type Options = AliasPieceOptions;
+	type Context = PieceContext;
+	type JSON = AliasPieceJSON;
+}

--- a/src/lib/structures/AliasPiece.ts
+++ b/src/lib/structures/AliasPiece.ts
@@ -41,6 +41,7 @@ export interface AliasPieceJSON extends PieceJSON {
 	options: AliasPieceOptions;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace AliasPiece {
 	type Options = AliasPieceOptions;
 	type Context = PieceContext;

--- a/src/lib/structures/AliasPiece.ts
+++ b/src/lib/structures/AliasPiece.ts
@@ -43,7 +43,7 @@ export interface AliasPieceJSON extends PieceJSON {
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace AliasPiece {
-	type Options = AliasPieceOptions;
-	type Context = PieceContext;
-	type JSON = AliasPieceJSON;
+	export type Options = AliasPieceOptions;
+	export type Context = PieceContext;
+	export type JSON = AliasPieceJSON;
 }

--- a/src/lib/structures/AliasPiece.ts
+++ b/src/lib/structures/AliasPiece.ts
@@ -41,7 +41,6 @@ export interface AliasPieceJSON extends PieceJSON {
 	options: AliasPieceOptions;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace AliasPiece {
 	export type Options = AliasPieceOptions;
 	export type Context = PieceContext;

--- a/src/lib/structures/Piece.ts
+++ b/src/lib/structures/Piece.ts
@@ -145,6 +145,7 @@ export interface PieceJSON {
 	options: PieceOptions;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Piece {
 	type Options = PieceOptions;
 	type Context = PieceContext;

--- a/src/lib/structures/Piece.ts
+++ b/src/lib/structures/Piece.ts
@@ -147,7 +147,7 @@ export interface PieceJSON {
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Piece {
-	type Options = PieceOptions;
-	type Context = PieceContext;
-	type JSON = PieceJSON;
+	export type Options = PieceOptions;
+	export type Context = PieceContext;
+	export type JSON = PieceJSON;
 }

--- a/src/lib/structures/Piece.ts
+++ b/src/lib/structures/Piece.ts
@@ -144,3 +144,9 @@ export interface PieceJSON {
 	enabled: boolean;
 	options: PieceOptions;
 }
+
+export namespace Piece {
+	type Options = PieceOptions;
+	type Context = PieceContext;
+	type JSON = PieceJSON;
+}

--- a/src/lib/structures/Piece.ts
+++ b/src/lib/structures/Piece.ts
@@ -145,7 +145,6 @@ export interface PieceJSON {
 	options: PieceOptions;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Piece {
 	export type Options = PieceOptions;
 	export type Context = PieceContext;

--- a/yarn.lock
+++ b/yarn.lock
@@ -359,9 +359,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sapphire/eslint-config@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "@sapphire/eslint-config@npm:4.0.3"
+"@sapphire/eslint-config@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@sapphire/eslint-config@npm:4.0.4"
   dependencies:
     "@typescript-eslint/eslint-plugin": ^5.3.0
     "@typescript-eslint/parser": ^5.3.0
@@ -370,7 +370,7 @@ __metadata:
     eslint-plugin-prettier: ^4.0.0
     prettier: ^2.4.1
     typescript: ^4.4.4
-  checksum: d38dc0053a74f98750d4b40cb5f627b022e300a6d2fcef9b532cdf78dc1d911ca3badfc386f101478ab13d3ef51944af97d2f75bc72b532dc1abb3d1dc6a1a72
+  checksum: 76c408f5f0f7173033c41573b3b4ae1de2a7b94c5620be5ddcf7a3a2dc1f10f785deb4e12e20e578431bdd700a241a3369b6ecba0630dc3bfe35c21bc53d6a6b
   languageName: node
   linkType: hard
 
@@ -392,7 +392,7 @@ __metadata:
     "@discordjs/collection": ^0.3.2
     "@favware/npm-deprecate": ^1.0.4
     "@favware/rollup-type-bundler": ^1.0.6
-    "@sapphire/eslint-config": ^4.0.3
+    "@sapphire/eslint-config": ^4.0.4
     "@sapphire/prettier-config": ^1.2.4
     "@sapphire/ts-config": ^3.1.4
     "@sapphire/utilities": ^3.0.7


### PR DESCRIPTION
After and if this is merged, I'll create a PR in `/framework` to add namespaces to `Command`, `Listener`, and `Argument`, and migrate the use of all of the affected interfaces/enums to using the namespace.