### PR TITLE
chore: fix container extend example

### DIFF
--- a/src/lib/shared/Container.ts
+++ b/src/lib/shared/Container.ts
@@ -23,7 +23,7 @@ export interface Container {
  * @example
  * ```typescript
  * // Add a reference for the version:
- * import { container } from '@sapphire/framework';
+ * import { container } from '@sapphire/pieces';
  *
  * container.version = '1.0.0';
  *

--- a/src/lib/shared/Container.ts
+++ b/src/lib/shared/Container.ts
@@ -23,15 +23,9 @@ export interface Container {
  * @example
  * ```typescript
  * // Add a reference for the version:
- * import { container, SapphireClient } from '@sapphire/framework';
+ * import { container } from '@sapphire/framework';
  *
- * export class MyClient extends SapphireClient {
- *   constructor(options) {
- *     super(options);
- *
- *     container.version = '1.0.0';
- *   }
- * }
+ * container.version = '1.0.0';
  *
  * // Can be placed anywhere in a TypeScript file, for JavaScript projects,
  * // you can create an `augments.d.ts` and place the code there.

--- a/src/lib/shared/Container.ts
+++ b/src/lib/shared/Container.ts
@@ -22,14 +22,14 @@ export interface Container {
  *
  * @example
  * ```typescript
- * // Add a reference to the Client:
- * import { container } from '@sapphire/pieces';
+ * // Add a reference for the version:
+ * import { container, SapphireClient } from '@sapphire/framework';
  *
- * export class SapphireClient extends Client {
+ * export class MyClient extends SapphireClient {
  *   constructor(options) {
  *     super(options);
  *
- *     container.client = this;
+ *     container.version = '1.0.0';
  *   }
  * }
  *
@@ -37,15 +37,15 @@ export interface Container {
  * // you can create an `augments.d.ts` and place the code there.
  * declare module '@sapphire/pieces' {
  *   interface Container {
- *     client: SapphireClient;
+ *     version: string;
  *   }
  * }
  *
  * // In any piece, core, plugin, or custom:
  * export class UserCommand extends Command {
  *   public run(message, args) {
- *     // The injected client is available here:
- *     const { client } = this.container;
+ *     // The injected version is available here:
+ *     const { version } = this.container;
  *
  *     // ...
  *   }


### PR DESCRIPTION
Current example explains how to inject the `client` property in container which is invalid because it's already available in `container`. Replaced it with simple example to not create confusion.