### PR TITLE
fix(store): support abstract classes

### DIFF
--- a/src/lib/strategies/LoaderStrategy.ts
+++ b/src/lib/strategies/LoaderStrategy.ts
@@ -6,7 +6,7 @@ import { mjsImport } from '../internal/internal';
 import { getRootData } from '../internal/RootScan';
 import type { Piece } from '../structures/Piece';
 import type { Store } from '../structures/Store';
-import type { AsyncPreloadResult, FilterResult, ILoaderResult, ILoaderStrategy, ModuleData } from './ILoaderStrategy';
+import type { AsyncPreloadResult, FilterResult, ILoaderResult, ILoaderResultEntry, ILoaderStrategy, ModuleData } from './ILoaderStrategy';
 import { classExtends, isClass } from './Shared';
 
 /**
@@ -75,7 +75,7 @@ export class LoaderStrategy<T extends Piece> implements ILoaderStrategy<T> {
 		// Support any other export:
 		for (const value of Object.values(result)) {
 			if (isClass(value) && classExtends(value, store.Constructor)) {
-				yield value;
+				yield value as ILoaderResultEntry<T>;
 				yielded = true;
 			}
 		}

--- a/src/lib/strategies/Shared.ts
+++ b/src/lib/strategies/Shared.ts
@@ -1,11 +1,11 @@
-import type { Ctor } from '@sapphire/utilities';
+import type { AbstractCtor } from '@sapphire/utilities';
 
 /**
  * Determines whether or not a value is a class.
  * @param value The piece to be checked.
  * @private
  */
-export function isClass(value: unknown): value is Ctor {
+export function isClass(value: unknown): value is AbstractCtor {
 	return typeof value === 'function' && typeof value.prototype === 'object';
 }
 
@@ -15,8 +15,8 @@ export function isClass(value: unknown): value is Ctor {
  * @param base The base constructor.
  * @private
  */
-export function classExtends<T extends Ctor>(value: Ctor, base: T): value is T {
-	let ctor: Ctor | null = value;
+export function classExtends<T extends AbstractCtor>(value: AbstractCtor, base: T): value is T {
+	let ctor: AbstractCtor | null = value;
 	while (ctor !== null) {
 		if (ctor.constructor === base.constructor) return true;
 		ctor = Object.getPrototypeOf(ctor);

--- a/src/lib/structures/Store.ts
+++ b/src/lib/structures/Store.ts
@@ -1,5 +1,5 @@
 import { Collection } from '@discordjs/collection';
-import type { Constructor } from '@sapphire/utilities';
+import type { AbstractConstructor } from '@sapphire/utilities';
 import { promises as fsp } from 'fs';
 import { join } from 'path';
 import { LoaderError, LoaderErrorType } from '../errors/LoaderError';
@@ -50,7 +50,7 @@ export interface StoreLogger {
  * The store class which contains {@link Piece}s.
  */
 export class Store<T extends Piece> extends Collection<string, T> {
-	public readonly Constructor: Constructor<T>;
+	public readonly Constructor: AbstractConstructor<T>;
 	public readonly name: string;
 	public readonly paths: Set<string>;
 	public readonly strategy: ILoaderStrategy<T>;
@@ -59,7 +59,7 @@ export class Store<T extends Piece> extends Collection<string, T> {
 	 * @param constructor The piece constructor this store loads.
 	 * @param options The options for the store.
 	 */
-	public constructor(constructor: Constructor<T>, options: StoreOptions<T>) {
+	public constructor(constructor: AbstractConstructor<T>, options: StoreOptions<T>) {
 		super();
 		this.Constructor = constructor;
 		this.name = options.name;


### PR DESCRIPTION
This will allow us to do `super(Command, { name: 'commands' })` without `as any`.
