### PR TITLE
feat: add URL support for register methods

### DIFF
--- a/src/lib/internal/Path.ts
+++ b/src/lib/internal/Path.ts
@@ -1,4 +1,4 @@
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 export type Path = string | URL;
 

--- a/src/lib/internal/Path.ts
+++ b/src/lib/internal/Path.ts
@@ -1,0 +1,8 @@
+import { fileURLToPath } from 'url';
+
+export type Path = string | URL;
+
+export function resolvePath(path: Path): string {
+	if (typeof path === 'string') return path;
+	return fileURLToPath(path);
+}

--- a/src/lib/structures/Store.ts
+++ b/src/lib/structures/Store.ts
@@ -3,6 +3,7 @@ import type { Constructor } from '@sapphire/utilities';
 import { promises as fsp } from 'fs';
 import { join } from 'path';
 import { LoaderError, LoaderErrorType } from '../errors/LoaderError';
+import { Path, resolvePath } from '../internal/Path';
 import { container, Container } from '../shared/Container';
 import type { HydratedModuleData, ILoaderResultEntry, ILoaderStrategy, ModuleData } from '../strategies/ILoaderStrategy';
 import { LoaderStrategy } from '../strategies/LoaderStrategy';
@@ -85,9 +86,11 @@ export class Store<T extends Piece> extends Collection<string, T> {
 	 *   .registerPath(resolve('third-party', 'commands'));
 	 * ```
 	 */
-	public registerPath(path: string): this {
-		this.paths.add(path);
-		Store.logger?.(`[STORE => ${this.name}] [REGISTER] Registered path '${path}'.`);
+	public registerPath(path: Path): this {
+		const root = resolvePath(path);
+
+		this.paths.add(root);
+		Store.logger?.(`[STORE => ${this.name}] [REGISTER] Registered path '${root}'.`);
 		return this;
 	}
 

--- a/src/lib/structures/StoreRegistry.ts
+++ b/src/lib/structures/StoreRegistry.ts
@@ -1,5 +1,6 @@
 import { Collection } from '@discordjs/collection';
 import { join } from 'path';
+import { Path, resolvePath } from '../internal/Path';
 import { getRootData } from '../internal/RootScan';
 import type { Piece } from './Piece';
 import type { Store } from './Store';
@@ -65,9 +66,10 @@ export class StoreRegistry extends Collection<Key, Value> {
 	 * @since 2.1.0
 	 * @param rootDirectory The root directory to register pieces at.
 	 */
-	public registerPath(rootDirectory = getRootData().root) {
+	public registerPath(rootDirectory: Path = getRootData().root) {
+		const root = resolvePath(rootDirectory);
 		for (const store of this.values() as IterableIterator<Store<Piece>>) {
-			store.registerPath(join(rootDirectory, store.name));
+			store.registerPath(join(root, store.name));
 		}
 	}
 


### PR DESCRIPTION
This way, URLs can be used without calling `fileURLToPath`.
