### PR TITLE
feat(esm): add more qs parameters

### DIFF
--- a/src/lib/strategies/LoaderStrategy.ts
+++ b/src/lib/strategies/LoaderStrategy.ts
@@ -53,6 +53,8 @@ export class LoaderStrategy<T extends Piece> implements ILoaderStrategy<T> {
 		if (mjs) {
 			const url = pathToFileURL(file.path);
 			url.searchParams.append('d', Date.now().toString());
+			url.searchParams.append('name', file.name);
+			url.searchParams.append('extension', file.extension);
 			return mjsImport(url);
 		}
 


### PR DESCRIPTION
ESM pieces can now use `import.meta.url.searchParams.get('name')` to get the name of the file (without extension) as well as `import.meta.url.searchParams.get('extension')` to get the file extension.
