### PR TITLE
feat: support loading ESModule TS files when using ts-node

### DIFF
--- a/src/lib/strategies/LoaderStrategy.ts
+++ b/src/lib/strategies/LoaderStrategy.ts
@@ -49,7 +49,7 @@ export class LoaderStrategy<T extends Piece> implements ILoaderStrategy<T> {
 	}
 
 	public async preload(file: ModuleData): AsyncPreloadResult<T> {
-		const mjs = file.extension === '.mjs' || (file.extension === '.js' && this.clientUsesESModules);
+		const mjs = file.extension === '.mjs' || (['.js', '.ts'].includes(file.extension) && this.clientUsesESModules);
 		if (mjs) {
 			const url = pathToFileURL(file.path);
 			url.searchParams.append('d', Date.now().toString());

--- a/src/lib/strategies/LoaderStrategy.ts
+++ b/src/lib/strategies/LoaderStrategy.ts
@@ -28,7 +28,7 @@ export class LoaderStrategy<T extends Piece> implements ILoaderStrategy<T> {
 		 * extensions.
 		 */
 		if (Reflect.has(process, Symbol.for('ts-node.register.instance')) || !isNullish(process.env.TS_NODE_DEV)) {
-			this.supportedExtensions.push('.ts');
+			this.supportedExtensions.push('.ts', '.cts', '.mts');
 			this.filterDtsFiles = true;
 		}
 	}
@@ -49,7 +49,7 @@ export class LoaderStrategy<T extends Piece> implements ILoaderStrategy<T> {
 	}
 
 	public async preload(file: ModuleData): AsyncPreloadResult<T> {
-		const mjs = file.extension === '.mjs' || (['.js', '.ts'].includes(file.extension) && this.clientUsesESModules);
+		const mjs = ['.mjs', '.mts'].includes(file.extension) || (['.js', '.ts'].includes(file.extension) && this.clientUsesESModules);
 		if (mjs) {
 			const url = pathToFileURL(file.path);
 			url.searchParams.append('d', Date.now().toString());


### PR DESCRIPTION
This PR fixes the issue that ESModule `.ts` files fail to be loaded and `.cts` / `.mts` files are not recognized when using [`ts-node`](https://www.npmjs.com/package/ts-node) or any of TypeScript executors.

Currently, the following errors occur if you run `ts-node` when your project was written in and set to ESModule:

```
Error when loading 'C:\Dev\my-bot\src\interaction-handlers\hello.ts': Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: C:\Dev\my-bot\src\interaction-handlers\hello.ts
require() of ES modules is not supported.
require() of C:\Dev\my-bot\src\interaction-handlers\hello.ts from C:\Dev\my-bot\node_modules\.pnpm\@sapphire+pieces@3.5.2\node_modules\@sapphire\pieces\dist\lib\strategies\LoaderStrategy.js is an ES module file as it is a .ts file whose nearest parent package.json contains "type": "module" which defines all .ts files in that package scope as ES modules.
Instead change the requiring code to use import(), or remove "type": "module" from C:\Dev\my-bot\package.json.

    at createErrRequireEsm (C:\Dev\my-bot\node_modules\.pnpm\ts-node@10.9.1_evej5wzm4hojmu6uzxwpspdmsu\node_modules\ts-node\dist-raw\node-internal-errors.js:46:15)
    at assertScriptCanLoadAsCJSImpl (C:\Dev\my-bot\node_modules\.pnpm\ts-node@10.9.1_evej5wzm4hojmu6uzxwpspdmsu\node_modules\ts-node\dist-raw\node-internal-modules-cjs-loader.js:584:11)
    at Object.require.extensions.<computed> [as .ts] (C:\Dev\my-bot\node_modules\.pnpm\ts-node@10.9.1_evej5wzm4hojmu6uzxwpspdmsu\node_modules\ts-node\src\index.ts:1610:5)
    at Module.load (node:internal/modules/cjs/loader:1037:32)
    at Function.Module._load (node:internal/modules/cjs/loader:878:12)
    at Module.require (node:internal/modules/cjs/loader:1061:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at LoaderStrategy.preload (C:\Dev\my-bot\node_modules\.pnpm\@sapphire+pieces@3.5.2\node_modules\@sapphire\pieces\src\lib\strategies\LoaderStrategy.ts:62:15)
    at LoaderStrategy.load (C:\Dev\my-bot\node_modules\.pnpm\@sapphire+pieces@3.5.2\node_modules\@sapphire\pieces\src\lib\strategies\LoaderStrategy.ts:69:29)
    at load.next (<anonymous>) {
  code: 'ERR_REQUIRE_ESM'
}

Error when loading 'C:\Dev\my-bot\src\commands\ping.ts': Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: C:\Dev\my-bot\src\commands\ping.ts
...
```

...and after I fixed the issue, I discovered that [`.cts` and `.mts` files are real](https://www.typescriptlang.org/docs/handbook/esm-node.html#new-file-extensions), so I added them as supported extensions too.