### PR TITLE
feat: omit files starting with `_` from loading

### DIFF
--- a/src/lib/strategies/LoaderStrategy.ts
+++ b/src/lib/strategies/LoaderStrategy.ts
@@ -42,7 +42,7 @@ export class LoaderStrategy<T extends Piece> implements ILoaderStrategy<T> {
 
 		// Retrieve the name of the file, return null if empty.
 		const name = basename(path, extension);
-		if (name === '') return null;
+		if (name === '' || name.startsWith('_')) return null;
 
 		// Return the name and extension.
 		return { extension, path, name };


### PR DESCRIPTION
While this is technically a breaking change, it's unlikely it affects anyone.

I'm also aware users can just extend `LoaderStrategy` to ignore files following naming schemes of their liking, however, none of this is documented, and it would be considered a very advanced topic, as it falls under the innermost core part of Sapphire.

This patch adds a little feature to exclude files which name start with `_` from being loaded. This comes with two large somewhat-common uses:

- **Partial logic-only files**:
  For example, consider a `reminder.ts` command that has several (≥6) subcommands, and each run very complex code, making the command have over 400 lines of code. With this feature, users will now be able to define `_reminder-add.ts`, `_reminder-delete.ts`, and so on, to split the subcommands code into different files.
- **Temporary files**:
  For example, consider a bot using Sapphire is being rewritten from JavaScript to TypeScript. There are two approaches for this, one is all-in-one, where you rewrite all pieces at once, and the other is doing so incrementally. Users who want to do the change incrementally will be able to rename `cmd.js` to `_cmd.js` and create a new `cmd.ts` with the new rewritten code. Once it's done, the old `_cmd.js` can be deleted. All of this could be in the same directory, allowing developers to find the old piece much faster than if it was tossed into another directory (possibly at root) which leads to organization and folder structure naming issues.
- **WIP piece marker**:
  If you are writing a new bot, and start writing all the command files to have a clear picture of what's written, users should be able to have them empty, rather than having to fill skeleton templates with `// TODO` comments and a [TODO browser extension](https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.todo-tree). Instead, having `_piece.ts` makes a good marker, specially since `_` takes preference in name ordering, taking them to the top and improving their visibility.
