### PR TITLE
fix: resolve issue with class extends utility

### DIFF
--- a/src/lib/strategies/Shared.ts
+++ b/src/lib/strategies/Shared.ts
@@ -18,7 +18,7 @@ export function isClass(value: unknown): value is AbstractCtor {
 export function classExtends<T extends AbstractCtor>(value: AbstractCtor, base: T): value is T {
 	let ctor: AbstractCtor | null = value;
 	while (ctor !== null) {
-		if (ctor.constructor === base.constructor) return true;
+		if (ctor === base) return true;
 		ctor = Object.getPrototypeOf(ctor);
 	}
 


### PR DESCRIPTION
- `ctor.constructor` is `Function`
- `base.constructor` is `Function`

They're not `Function` when they're instances of a class, but since we are comparing the constructors, their constructors are `Function`, since classes are basically functions, as such, the utility was always returning `true` for anything that is a class.

![Code_ZxIajm9ycK](https://github.com/sapphiredev/pieces/assets/24852502/7e9d5983-24d6-4845-a748-a0d9bba8aff0)

With this change, we're not longer comparing `Function`s, but rather, the classes themselves, and now it does load pieces only if compatible instances were found:

![Code_a29YWhoDTk](https://github.com/sapphiredev/pieces/assets/24852502/635e88b3-c565-49bd-b058-1157d19cd4f5)
