### PR TITLE
feat(StoreRegistry): add queue and virtual file support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@ import 'tslib';
 
 export * from './lib/errors/LoaderError';
 export * from './lib/errors/MissingExportsError';
-export * from './lib/internal/constants';
 export * from './lib/internal/RootScan';
+export { VirtualPath } from './lib/internal/constants';
 export * from './lib/shared/Container';
 export * from './lib/strategies/ILoaderStrategy';
 export * from './lib/strategies/LoaderStrategy';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import 'tslib';
 
 export * from './lib/errors/LoaderError';
 export * from './lib/errors/MissingExportsError';
+export * from './lib/internal/constants';
 export * from './lib/internal/RootScan';
 export * from './lib/shared/Container';
 export * from './lib/strategies/ILoaderStrategy';

--- a/src/lib/errors/LoaderError.ts
+++ b/src/lib/errors/LoaderError.ts
@@ -1,7 +1,9 @@
 export enum LoaderErrorType {
 	EmptyModule = 'EMPTY_MODULE',
+	VirtualPiece = 'VIRTUAL_PIECE',
 	UnloadedPiece = 'UNLOADED_PIECE',
-	IncorrectType = 'INCORRECT_TYPE'
+	IncorrectType = 'INCORRECT_TYPE',
+	UnknownStore = 'UNKNOWN_STORE'
 }
 
 /**

--- a/src/lib/internal/constants.ts
+++ b/src/lib/internal/constants.ts
@@ -1,1 +1,2 @@
 export const VirtualPath = '::virtual::';
+export const ManuallyRegisteredPiecesSymbol = Symbol('@sapphire/pieces:ManuallyRegisteredPieces');

--- a/src/lib/internal/constants.ts
+++ b/src/lib/internal/constants.ts
@@ -1,0 +1,1 @@
+export const VirtualPath = '::virtual::';

--- a/src/lib/structures/PieceLocation.ts
+++ b/src/lib/structures/PieceLocation.ts
@@ -1,4 +1,5 @@
 import { basename, relative, sep } from 'path';
+import { VirtualPath } from '../internal/constants';
 
 /**
  * The metadata class used for {@link Piece}s.
@@ -24,6 +25,13 @@ export class PieceLocation {
 	}
 
 	/**
+	 * Whether the file is virtual or not.
+	 */
+	public get virtual() {
+		return this.full === VirtualPath;
+	}
+
+	/**
 	 * The relative path between {@link PieceLocation.root} and {@link PieceLocation.full}.
 	 * @example
 	 * ```typescript
@@ -37,7 +45,7 @@ export class PieceLocation {
 	 * ```
 	 */
 	public get relative(): string {
-		return relative(this.root, this.full);
+		return this.virtual ? VirtualPath : relative(this.root, this.full);
 	}
 
 	/**
@@ -54,7 +62,7 @@ export class PieceLocation {
 	 * ```
 	 */
 	public get directories(): string[] {
-		return this.relative.split(sep).slice(0, -1);
+		return this.virtual ? [] : this.relative.split(sep).slice(0, -1);
 	}
 
 	/**
@@ -71,7 +79,7 @@ export class PieceLocation {
 	 * ```
 	 */
 	public get name(): string {
-		return basename(this.full);
+		return this.virtual ? VirtualPath : basename(this.full);
 	}
 
 	/**

--- a/src/lib/structures/Store.ts
+++ b/src/lib/structures/Store.ts
@@ -9,6 +9,7 @@ import type { HydratedModuleData, ILoaderResultEntry, ILoaderStrategy, ModuleDat
 import { LoaderStrategy } from '../strategies/LoaderStrategy';
 import type { Piece } from './Piece';
 import { StoreRegistry, type StoreRegistryEntries } from './StoreRegistry';
+import { VirtualPath } from '../internal/constants';
 
 /**
  * The options for the store, this features both hooks (changes the behaviour) and handlers (similar to event listeners).
@@ -101,6 +102,10 @@ export class Store<T extends Piece> extends Collection<string, T> {
 	 * @return All the loaded pieces.
 	 */
 	public async load(root: string, path: string): Promise<T[]> {
+		if (root === VirtualPath) {
+			throw new LoaderError(LoaderErrorType.VirtualPiece, `Cannot load a virtual file.`);
+		}
+
 		const full = join(root, path);
 		const data = this.strategy.filter(full);
 		if (data === null) {

--- a/src/lib/structures/StoreRegistry.ts
+++ b/src/lib/structures/StoreRegistry.ts
@@ -1,7 +1,10 @@
 import { Collection } from '@discordjs/collection';
+import { Constructor, classExtends, isClass } from '@sapphire/utilities';
 import { join } from 'path';
+import { LoaderError, LoaderErrorType } from '../errors/LoaderError';
 import { resolvePath, type Path } from '../internal/Path';
 import { getRootData } from '../internal/RootScan';
+import { VirtualPath } from '../internal/constants';
 import type { Piece } from './Piece';
 import type { Store } from './Store';
 
@@ -30,11 +33,30 @@ type Value = StoreRegistryEntries[Key];
  */
 export class StoreRegistry extends Collection<Key, Value> {
 	/**
+	 * The queue of pieces to load.
+	 */
+	readonly #loadQueue: StoreLoadPieceQueueEntry<keyof StoreRegistryEntries>[] = [];
+	/**
+	 * Whether or not the registry is loaded.
+	 */
+	#calledLoad = false;
+
+	/**
 	 * Loads all the registered stores.
 	 * @since 2.1.0
 	 */
 	public async load() {
-		const promises: Promise<void>[] = [];
+		this.#calledLoad = true;
+
+		const promises: Promise<unknown>[] = [];
+
+		// Load the queue first
+		for (const entry of this.#loadQueue) {
+			promises.push(this.#loadQueueEntry(entry));
+		}
+		this.#loadQueue.length = 0;
+
+		// Load from FS
 		for (const store of this.values() as IterableIterator<Store<Piece>>) {
 			promises.push(store.loadAll());
 		}
@@ -92,6 +114,74 @@ export class StoreRegistry extends Collection<Key, Value> {
 		this.delete(store.name as Key);
 		return this;
 	}
+
+	/**
+	 * If the registry's {@linkcode StoreRegistry.load()} method wasn't called yet, this method validates whether or not
+	 * `entry.piece` is a class, throwing a {@link TypeError} if it isn't, otherwise it will queue the entry for later
+	 * when {@linkcode StoreRegistry.load()} is called.
+	 *
+	 * If it was called, the entry will be loaded immediately without queueing.
+	 *
+	 * @remarks
+	 *
+	 * - Pieces loaded this way will have their {@linkcode Piece.Context.root root} and
+	 *   {@linkcode Piece.Context.path path} set to {@linkcode VirtualPath}, and as such, cannot be reloaded.
+	 * - This method is useful in environments where FS access is limited or unavailable, such as serverless.
+	 * - The loaded method will throw a {@linkcode LoaderError} if:
+	 *   - The store does not exist.
+	 *   - The piece does not extend the {@linkcode Store.Constructor store's piece constructor}.
+	 * - This operation is atomic, if any of the above errors are thrown, the piece will not be loaded.
+	 *
+	 * @since 3.8.0
+	 * @param entry The entry to load.
+	 * @example
+	 * ```typescript
+	 * import { container } from '@sapphire/pieces';
+	 *
+	 * class PingCommand extends Command {
+	 *   // ...
+	 * }
+	 *
+	 * container.stores.loadPiece({
+	 *   store: 'commands',
+	 *   name: 'ping',
+	 *   piece: PingCommand
+	 * });
+	 * ```
+	 */
+	public async loadPiece<StoreName extends keyof StoreRegistryEntries>(entry: StoreLoadPieceQueueEntry<StoreName>) {
+		if (!isClass(entry.piece)) {
+			throw new TypeError(`The piece ${entry.name} is not a Class. ${String(entry.piece)}`);
+		}
+
+		if (this.#calledLoad) {
+			await this.#loadQueueEntry(entry);
+		} else {
+			this.#loadQueue.push(entry);
+		}
+	}
+
+	/**
+	 * Loads a {@link StoreLoadPieceQueueEntry}.
+	 * @param entry The entry to load.
+	 * @returns The loaded piece.
+	 */
+	#loadQueueEntry<StoreName extends keyof StoreRegistryEntries>(entry: StoreLoadPieceQueueEntry<StoreName>) {
+		const store = this.get(entry.store) as Store<Piece> | undefined;
+
+		// If the store does not exist, throw an error:
+		if (!store) {
+			throw new LoaderError(LoaderErrorType.UnknownStore, `The store ${entry.store} does not exist.`);
+		}
+
+		// If the piece does not extend the store's Piece class, throw an error:
+		if (!classExtends(entry.piece, store.Constructor as Constructor<Piece>)) {
+			throw new LoaderError(LoaderErrorType.IncorrectType, `The piece ${entry.name} does not extend ${store.name}`);
+		}
+
+		const piece = store.construct(entry.piece, { name: entry.name, root: VirtualPath, path: VirtualPath, extension: VirtualPath });
+		return store.insert(piece);
+	}
 }
 
 export interface StoreRegistry {
@@ -106,3 +196,14 @@ export interface StoreRegistry {
  * @since 2.1.0
  */
 export interface StoreRegistryEntries {}
+
+/**
+ * The {@link StoreRegistry}'s load entry, use module augmentation against this interface when adding new stores.
+ * @seealso {@linkcode StoreRegistry.loadPiece()}
+ * @since 3.8.0
+ */
+export interface StoreLoadPieceQueueEntry<StoreName extends keyof StoreRegistryEntries> {
+	store: StoreName;
+	name: string;
+	piece: StoreRegistryEntries[StoreName] extends Store<infer Piece> ? Constructor<Piece> : never;
+}

--- a/src/lib/structures/StoreRegistry.ts
+++ b/src/lib/structures/StoreRegistry.ts
@@ -126,7 +126,8 @@ export class StoreRegistry extends Collection<Key, Value> {
 	 *
 	 * - Pieces loaded this way will have their {@linkcode Piece.Context.root root} and
 	 *   {@linkcode Piece.Context.path path} set to {@linkcode VirtualPath}, and as such, cannot be reloaded.
-	 * - This method is useful in environments where FS access is limited or unavailable, such as serverless.
+	 * - This method is useful in environments where file system access is limited or unavailable, such as when using
+	 * 	 {@link https://en.wikipedia.org/wiki/Serverless_computing Serverless Computing}.
 	 * - The loaded method will throw a {@linkcode LoaderError} if:
 	 *   - The store does not exist.
 	 *   - The piece does not extend the {@linkcode Store.Constructor store's piece constructor}.


### PR DESCRIPTION
Adds a new method, `container.stores.loadPiece()`, which loads or queues a piece into the piece registries. Useful specially for running Sapphire bots in environments where FS is limited or unavailable.

Usage example:
```typescript
import { Command, container } from '@sapphire/framework';

class PingCommand extends Command {
  // ...
}

container.stores.loadPiece({
  store: 'commands',
  name: 'ping',
  piece: PingCommand
});
```

The `virtual` name was chosen as an inspiration to Vue's virtual modules, where they create dynamic modules prefixed with `virtual:`.