### PR TITLE
fix(AliasStore): pass `StoreName` type parameter to `Store`

### DIFF
--- a/src/lib/structures/AliasStore.ts
+++ b/src/lib/structures/AliasStore.ts
@@ -1,11 +1,12 @@
 import { Collection } from '@discordjs/collection';
 import type { AliasPiece } from './AliasPiece';
 import { Store } from './Store';
+import type { StoreRegistryEntries } from './StoreRegistry';
 
 /**
  * The store class which contains {@link AliasPiece}s.
  */
-export class AliasStore<T extends AliasPiece> extends Store<T> {
+export class AliasStore<T extends AliasPiece, StoreName extends keyof StoreRegistryEntries = keyof StoreRegistryEntries> extends Store<T, StoreName> {
 	/**
 	 * The aliases referencing to pieces.
 	 */


### PR DESCRIPTION
Found while updating https://github.com/sapphiredev/framework/pull/686 to use the new `StoreName` type parameter
