### PR TITLE
feat(StoreRegistry): add `StoreOf` and `PieceOf`

### DIFF
--- a/src/lib/structures/AliasPiece.ts
+++ b/src/lib/structures/AliasPiece.ts
@@ -1,4 +1,5 @@
 import { Piece } from './Piece';
+import type { StoreRegistryEntries } from './StoreRegistry';
 
 export interface AliasPieceOptions extends Piece.Options {
 	/**
@@ -11,7 +12,10 @@ export interface AliasPieceOptions extends Piece.Options {
 /**
  * The piece to be stored in {@link AliasStore} instances.
  */
-export class AliasPiece<O extends AliasPieceOptions = AliasPieceOptions> extends Piece<O> {
+export class AliasPiece<
+	Options extends AliasPieceOptions = AliasPieceOptions,
+	StoreName extends keyof StoreRegistryEntries = keyof StoreRegistryEntries
+> extends Piece<Options, StoreName> {
 	/**
 	 * The aliases for the piece.
 	 */

--- a/src/lib/structures/Piece.ts
+++ b/src/lib/structures/Piece.ts
@@ -2,6 +2,7 @@ import type { Awaitable } from '@sapphire/utilities';
 import { container, type Container } from '../shared/Container';
 import { PieceLocation, type PieceLocationJSON } from './PieceLocation';
 import type { Store } from './Store';
+import type { StoreOf, StoreRegistryEntries } from './StoreRegistry';
 
 /**
  * The context for the piece, contains extra information from the store,
@@ -49,11 +50,11 @@ export interface PieceOptions {
 /**
  * The piece to be stored in {@link Store} instances.
  */
-export class Piece<O extends PieceOptions = PieceOptions> {
+export class Piece<Options extends PieceOptions = PieceOptions, StoreName extends keyof StoreRegistryEntries = keyof StoreRegistryEntries> {
 	/**
 	 * The store that contains the piece.
 	 */
-	public readonly store: Store<Piece>;
+	public readonly store: StoreOf<StoreName>;
 
 	/**
 	 * The location metadata for the piece's file.
@@ -73,14 +74,14 @@ export class Piece<O extends PieceOptions = PieceOptions> {
 	/**
 	 * The raw options passed to this {@link Piece}
 	 */
-	public readonly options: O;
+	public readonly options: Options;
 
 	public constructor(context: PieceContext, options: PieceOptions = {}) {
 		this.store = context.store;
 		this.location = new PieceLocation(context.path, context.root);
 		this.name = options.name ?? context.name;
 		this.enabled = options.enabled ?? true;
-		this.options = options as O;
+		this.options = options as Options;
 	}
 
 	/**

--- a/src/lib/structures/StoreRegistry.ts
+++ b/src/lib/structures/StoreRegistry.ts
@@ -1,4 +1,5 @@
 import { Collection } from '@discordjs/collection';
+import { isClass } from '@sapphire/utilities';
 import { join } from 'path';
 import { LoaderError } from '../errors/LoaderError';
 import { resolvePath, type Path } from '../internal/Path';
@@ -6,7 +7,6 @@ import { getRootData } from '../internal/RootScan';
 import { ManuallyRegisteredPiecesSymbol, VirtualPath } from '../internal/constants';
 import type { Piece } from './Piece';
 import type { Store, StoreManuallyRegisteredPiece } from './Store';
-import { isClass } from '@sapphire/utilities';
 
 type Key = keyof StoreRegistryEntries;
 type Value = StoreRegistryEntries[Key];
@@ -204,3 +204,19 @@ export interface StoreRegistryEntries {}
 export interface StoreManagerManuallyRegisteredPiece<StoreName extends keyof StoreRegistryEntries> extends StoreManuallyRegisteredPiece<StoreName> {
 	store: StoreName;
 }
+
+/**
+ * Type utility to get the {@linkcode Store} given its name.
+ */
+export type StoreOf<StoreName extends keyof StoreRegistryEntries> = keyof StoreRegistryEntries extends never
+	? Store<Piece<Piece.Options, StoreName>>
+	: StoreRegistryEntries[StoreName];
+
+/**
+ * Type utility to get the {@linkcode Piece} given its {@linkcode Store}'s name.
+ */
+export type PieceOf<StoreName extends keyof StoreRegistryEntries> = keyof StoreRegistryEntries extends never
+	? Piece<Piece.Options, StoreName>
+	: StoreRegistryEntries[StoreName] extends Store<infer PieceType>
+	  ? PieceType
+	  : Piece<Piece.Options, StoreName>;


### PR DESCRIPTION
With this PR, `Piece#store` is now typed as `StoreOf<StoreName>`, which means that by passing a second type parameter in the piece's class, `StoreName`, the type gets strictly typed as the store that contains it. For example, in Framework, `StoreOf<'commands'>` returns `CommandStore`, and `PieceOf<'commands'>` returns `Command<Args, CommandOptions>`,

