### PR TITLE
fix: make virtual pieces respect name restrictions like normal pieces

### DIFF
--- a/src/lib/structures/Store.ts
+++ b/src/lib/structures/Store.ts
@@ -61,7 +61,7 @@ export class Store<T extends Piece, StoreName extends StoreRegistryKey = StoreRe
 	/**
 	 * The queue of manually registered pieces to load.
 	 */
-	private readonly [ManuallyRegisteredPiecesSymbol]: StoreManuallyRegisteredPiece<StoreName>[] = [];
+	private readonly [ManuallyRegisteredPiecesSymbol] = new Map<string, StoreManuallyRegisteredPiece<StoreName>>();
 
 	/**
 	 * Whether or not the store has called `loadAll` at least once.
@@ -161,7 +161,7 @@ export class Store<T extends Piece, StoreName extends StoreRegistryKey = StoreRe
 			throw new LoaderError(LoaderErrorType.IncorrectType, `The piece ${entry.name} does not extend ${this.name}`);
 		}
 
-		this[ManuallyRegisteredPiecesSymbol].push(entry);
+		this[ManuallyRegisteredPiecesSymbol].set(entry.name, entry);
 		if (this.#calledLoadAll) {
 			const piece = this.construct(entry.piece as unknown as Constructor<T>, {
 				name: entry.name,
@@ -242,7 +242,7 @@ export class Store<T extends Piece, StoreName extends StoreRegistryKey = StoreRe
 		this.#calledLoadAll = true;
 
 		const pieces: T[] = [];
-		for (const entry of this[ManuallyRegisteredPiecesSymbol]) {
+		for (const entry of this[ManuallyRegisteredPiecesSymbol].values()) {
 			const piece = this.construct(entry.piece as unknown as Constructor<T>, {
 				name: entry.name,
 				root: VirtualPath,

--- a/src/lib/structures/StoreRegistry.ts
+++ b/src/lib/structures/StoreRegistry.ts
@@ -108,7 +108,10 @@ export class StoreRegistry extends Collection<StoreRegistryKey, StoreRegistryVal
 		// If there was a queue for this store, add it to the store and delete the queue:
 		const queue = this.#pendingManuallyRegisteredPieces.get(store.name);
 		if (queue) {
-			store[ManuallyRegisteredPiecesSymbol].push(...queue);
+			for (const entry of queue) {
+				store[ManuallyRegisteredPiecesSymbol].set(entry.name, entry);
+			}
+
 			this.#pendingManuallyRegisteredPieces.delete(store.name);
 		}
 


### PR DESCRIPTION
Fixes ONE of the issues with Deno >.>

The others we cannot fix as they're at the runtime's control