### PR TITLE
fix: fixed checking for tsx support

### DIFF
--- a/src/lib/strategies/env.ts
+++ b/src/lib/strategies/env.ts
@@ -11,6 +11,10 @@ function checkPreloadModules(name: string) {
 	return '_preload_modules' in process && (process._preload_modules as string[]).includes(name);
 }
 
+function checkPreloadModulesSubstring(name: string) {
+	return '_preload_modules' in process && (process._preload_modules as string[]).some((module) => module.includes(name));
+}
+
 function checkEnvVariable(name: string, value?: string) {
 	return value ? process.env[name] === value : !isNullish(process.env[name]);
 }
@@ -70,4 +74,4 @@ export const CanLoadTypeScriptFiles: boolean =
 	checkPreloadModules('esbuild-register') ||
 	//
 	// tsx
-	checkPreloadModules('tsx');
+	checkPreloadModulesSubstring('tsx');

--- a/src/lib/strategies/env.ts
+++ b/src/lib/strategies/env.ts
@@ -8,10 +8,6 @@ function checkProcessArgv(name: string) {
 }
 
 function checkPreloadModules(name: string) {
-	return '_preload_modules' in process && (process._preload_modules as string[]).includes(name);
-}
-
-function checkPreloadModulesSubstring(name: string) {
 	return '_preload_modules' in process && (process._preload_modules as string[]).some((module) => module.includes(name));
 }
 
@@ -74,4 +70,4 @@ export const CanLoadTypeScriptFiles: boolean =
 	checkPreloadModules('esbuild-register') ||
 	//
 	// tsx
-	checkPreloadModulesSubstring('tsx');
+	checkPreloadModules('tsx');


### PR DESCRIPTION
Added
- function `checkPreloadModulesSubstring`

Small fix for TS environment support. `tsx` has to be searched as a substring when it's present in `process._preload_modules` as the string takes a form similar to:
```js
['path_to_project_or_npm/node_modules/tsx/dist/preflight.cjs']
```
Function may be used in the future by modules similarly loaded like this.