### PR TITLE
fix(RootScan): check for runtime config files when checking for CJS vs ESM

### DIFF
--- a/src/lib/internal/RootScan.ts
+++ b/src/lib/internal/RootScan.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { dirname, join } from 'path';
 
 /**
@@ -82,7 +82,8 @@ export function parseRootData(): RootData {
 	try {
 		file = JSON.parse(readFileSync(join(cwd, 'package.json'), 'utf8')) as PartialPackageJson;
 	} catch (error) {
-		return { root: cwd, type: 'CommonJS' };
+		const hasDenoConfigFile = existsSync(join(cwd, 'deno.json'));
+		return hasDenoConfigFile ? { root: cwd, type: 'ESM' } : { root: cwd, type: 'CommonJS' };
 	}
 
 	const { main: packageMain, module: packageModule, type: packageType } = file;

--- a/src/lib/internal/RootScan.ts
+++ b/src/lib/internal/RootScan.ts
@@ -83,7 +83,8 @@ export function parseRootData(): RootData {
 		file = JSON.parse(readFileSync(join(cwd, 'package.json'), 'utf8')) as PartialPackageJson;
 	} catch (error) {
 		const hasDenoConfigFile = existsSync(join(cwd, 'deno.json'));
-		return hasDenoConfigFile ? { root: cwd, type: 'ESM' } : { root: cwd, type: 'CommonJS' };
+		const hasBunConfigFile = existsSync(join(cwd, 'bunfig.toml'));
+		return hasDenoConfigFile || hasBunConfigFile ? { root: cwd, type: 'ESM' } : { root: cwd, type: 'CommonJS' };
 	}
 
 	const { main: packageMain, module: packageModule, type: packageType } = file;


### PR DESCRIPTION
This pull request includes changes to the `src/lib/internal/RootScan.ts` file to enhance the detection of project type by checking for the presence of a Deno configuration file.

Enhancements to project type detection:

* [`src/lib/internal/RootScan.ts`](diffhunk://#diff-185d0a50c8603a9e51efb1af56d9f33f9688f896199998586f926ba07b8dbe9bL1-R1): Added `existsSync` import from the `fs` module to check for the presence of the `deno.json` file.
* [`export function parseRootData()`](diffhunk://#diff-185d0a50c8603a9e51efb1af56d9f33f9688f896199998586f926ba07b8dbe9bL85-R86): Modified the function to return `{ root: cwd, type: 'ESM' }` if `deno.json` is found, otherwise return `{ root: cwd, type: 'CommonJS' }`.

Closes #474