### PR TITLE
fix: clear import cache for pieces when using Bun

### DIFF
--- a/src/lib/strategies/LoaderStrategy.ts
+++ b/src/lib/strategies/LoaderStrategy.ts
@@ -58,12 +58,8 @@ export class LoaderStrategy<T extends Piece> implements ILoaderStrategy<T> {
 			url.searchParams.append('name', file.name);
 			url.searchParams.append('extension', file.extension);
 
-			// Bun workaround: Strips URI scheme for dynamic imports to force re-evaluation due to caching bug.
-			if (Reflect.has(globalThis, 'Bun')) {
-				const isWindows = process.platform === 'win32';
-				const scheme = isWindows ? 'file:///' : 'file://';
-				return mjsImport(url.href.slice(scheme.length));
-			}
+			// Bun workaround: Import a file path with search params instead of an file URL to force re-evaluation due to caching bug.
+			if (Reflect.has(globalThis, 'Bun')) return mjsImport(file.path + url.search);
 
 			return mjsImport(url);
 		}


### PR DESCRIPTION
This PR fixes a bug preventing pieces from updating when reloaded if using Bun.

The issue was caused by Bun's import cache serving the old, cached version of the piece file instead of loading the updated one.

The solution was to clear the import cache of any piece file before loading it, which can be accessed with `require.cache` in Bun, even when using Typescript or ESM.